### PR TITLE
Fix blob path configuration in DepthAI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ python scripts/convert_to_onnx.py
 See `scripts/convert_onnx_to_blob.md` for instructions on producing a `.blob` for DepthAI devices.
 
 ### DepthAI Demo
-Connect an OAK camera and run:
+Connect an OAK camera and run the demo by providing paths to both the
+gesture classifier and BlazePose blobs:
 
 ```bash
-python scripts/run_depthai.py
+python scripts/run_depthai.py --classifier-blob models/deployed/pose_classifier_oak.blob \
+                             --pose-blob path/to/blazepose.blob
 ```
 
 ## Additional Utilities

--- a/scripts/run_depthai.py
+++ b/scripts/run_depthai.py
@@ -1,17 +1,22 @@
+import argparse
 import os
 from src.blazepoze.pipeline.depthai import DepthAIPipeline
 
 
-def main(file=None):
+def main(classifier_blob=None, pose_blob=None):
     try:
-        if not file:
+        if not classifier_blob or not pose_blob:
             raise ValueError("Blob file path not provided")
 
-        if not os.path.exists(file):
-            raise FileNotFoundError(f"Blob file not found at path: {file}")
+        if not os.path.exists(classifier_blob):
+            raise FileNotFoundError(f"Blob file not found at path: {classifier_blob}")
+
+        if not os.path.exists(pose_blob):
+            raise FileNotFoundError(f"Blob file not found at path: {pose_blob}")
 
         pipeline = DepthAIPipeline(
-            blob_file_path=file
+            blob_file_path=classifier_blob,
+            blazepose_blob_path=pose_blob,
         )
         print("Before connecting the device: ", pipeline)
         pipeline.connectDevice()
@@ -21,5 +26,16 @@ def main(file=None):
 
 
 if __name__ == "__main__":
-    blob_file_path = "/Users/pedrootavionascimentocamposdeoliveira/PycharmProjects/hiveLabResearch/models/deployed/pose_classifier_oak.blob"
-    main(blob_file_path)
+    parser = argparse.ArgumentParser(description="Run DepthAI gesture pipeline")
+    parser.add_argument(
+        "--classifier-blob",
+        default="models/deployed/pose_classifier_oak.blob",
+        help="Path to the gesture classifier blob",
+    )
+    parser.add_argument(
+        "--pose-blob",
+        default="blazepose.blob",
+        help="Path to the BlazePose blob",
+    )
+    args = parser.parse_args()
+    main(args.classifier_blob, args.pose_blob)


### PR DESCRIPTION
## Summary
- add checks for classifier and BlazePose blob paths
- allow passing both blob paths to DepthAIPipeline
- update run_depthai.py to use argparse and pass blob locations
- document new usage in README

## Testing
- `PYTHONPATH=./ pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b189a70c83309be2a3582a0610d6