### PR TITLE
Refactor DepthAI pipeline

### DIFF
--- a/scripts/run_depthai.py
+++ b/scripts/run_depthai.py
@@ -1,12 +1,14 @@
 import argparse
 import os
 from src.blazepoze.pipeline.depthai import DepthAIPipeline
+from src.blazepoze.visualization.visualization_utils import VisualizationUtils
 
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-def main(classifier_blob=None, pose_blob=None):
+def main(classifier_blob=None, pose_blob=None, display=True):
+    VisualizationUtils.display_enabled = display
     try:
         # Resolve to full paths relative to project root
         classifier_blob = os.path.join(PROJECT_ROOT, classifier_blob)
@@ -41,5 +43,10 @@ if __name__ == "__main__":
         default="/Users/pedrootavionascimentocamposdeoliveira/PycharmProjects/hiveLabResearch/depthai_blazepose/models/pose_landmark_full_sh4.blob",
         help="Path to the BlazePose blob",
     )
+    parser.add_argument(
+        "--no-display",
+        action="store_true",
+        help="Disable OpenCV image display",
+    )
     args = parser.parse_args()
-    main(args.classifier_blob, args.pose_blob)
+    main(args.classifier_blob, args.pose_blob, not args.no_display)

--- a/scripts/run_depthai_buffer.py
+++ b/scripts/run_depthai_buffer.py
@@ -2,6 +2,7 @@ import argparse
 import os
 # The new class name is PoseActionClassifier
 from src.blazepoze.pipeline.depthai_simplified_buffer import PoseActionClassifier
+from src.blazepoze.visualization.visualization_utils import VisualizationUtils
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -38,6 +39,7 @@ def main(args):
         lm_model_path=lm_model,
         labels=labels
     )
+    VisualizationUtils.display_enabled = not args.no_display
     pipeline.run()
 
 
@@ -65,6 +67,11 @@ if __name__ == "__main__":
         "--label_file",
         default="labels.txt",
         help="Optional path to a text file with class labels.",
+    )
+    parser.add_argument(
+        "--no-display",
+        action="store_true",
+        help="Disable OpenCV image display",
     )
 
     args = parser.parse_args()

--- a/scripts/run_depthai_simplified.py
+++ b/scripts/run_depthai_simplified.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from src.blazepoze.pipeline.depthai_simplified import DepthAIClassifier
+from src.blazepoze.visualization.visualization_utils import VisualizationUtils
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -15,7 +16,8 @@ def read_labels(label_file):
         return [line.strip() for line in f if line.strip()]
 
 
-def main(classifier_blob, label_file=None):
+def main(classifier_blob, label_file=None, display=True):
+    VisualizationUtils.display_enabled = display
     classifier_blob = os.path.join(PROJECT_ROOT, classifier_blob)
     if not os.path.exists(classifier_blob):
         raise FileNotFoundError(f"Classifier blob not found at: {classifier_blob}")
@@ -38,5 +40,10 @@ if __name__ == "__main__":
         default=None,
         help="Optional path to a text file with class labels",
     )
+    parser.add_argument(
+        "--no-display",
+        action="store_true",
+        help="Disable OpenCV image display",
+    )
     args = parser.parse_args()
-    main(args.classifier_blob, args.label_file)
+    main(args.classifier_blob, args.label_file, not args.no_display)

--- a/src/blazepoze/pipeline/__init__.py
+++ b/src/blazepoze/pipeline/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline_manager import PipelineManager
+
+__all__ = ["PipelineManager"]

--- a/src/blazepoze/pipeline/pipeline_manager.py
+++ b/src/blazepoze/pipeline/pipeline_manager.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Any, Callable
+
+import cv2 as cv
+
+try:  # DepthAI may not be installed when running unit tests
+    import depthai as dai
+except Exception:  # pragma: no cover - imported at runtime on device
+    dai = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineManager:
+    """Utility class to manage DepthAI device lifecycle."""
+
+    def __init__(self, pipeline: Any) -> None:
+        self.pipeline = pipeline
+
+    @staticmethod
+    def validate_device_available() -> None:
+        """Ensure that at least one DepthAI device is connected."""
+        if dai is None:
+            return
+
+        if not dai.Device.getAllAvailableDevices():
+            raise RuntimeError(
+                "No DepthAI device found! Please ensure that the camera is connected"
+            )
+
+    def run(
+        self,
+        queue_setup: Callable[[Any], None],
+        loop_body: Callable[[], None],
+    ) -> None:
+        """Create the device, initialize queues and execute the loop."""
+        if dai is None:
+            raise RuntimeError("DepthAI library is not available")
+
+        self.validate_device_available()
+
+        with dai.Device(self.pipeline) as device:
+            queue_setup(device)
+            loop_body()
+
+        cv.destroyAllWindows()

--- a/src/blazepoze/visualization/__init__.py
+++ b/src/blazepoze/visualization/__init__.py
@@ -1,0 +1,4 @@
+from .pose_visualizer import PoseVisualizer
+from .visualization_utils import VisualizationUtils
+
+__all__ = ["PoseVisualizer", "VisualizationUtils"]

--- a/src/blazepoze/visualization/visualization_utils.py
+++ b/src/blazepoze/visualization/visualization_utils.py
@@ -1,0 +1,34 @@
+"""Lightweight helpers for OpenCV visualizations."""
+
+from typing import Tuple
+
+import cv2 as cv
+import numpy as np
+
+
+class VisualizationUtils:
+    """Utility wrapper for OpenCV display functions."""
+
+    display_enabled: bool = True
+
+    @staticmethod
+    def overlay_text(
+        frame: np.ndarray,
+        text: str,
+        position: Tuple[int, int] = (10, 30),
+        color: Tuple[int, int, int] = (0, 255, 0),
+        scale: float = 1.0,
+        thickness: int = 2,
+    ) -> None:
+        """Draw text on an image in-place."""
+        cv.putText(frame, text, position, cv.FONT_HERSHEY_SIMPLEX, scale, color, thickness)
+
+    @staticmethod
+    def show_image(window_name: str, frame: np.ndarray) -> bool:
+        """Display an image if enabled and return ``False`` when ``q`` is pressed."""
+        if not VisualizationUtils.display_enabled:
+            return True
+
+        cv.imshow(window_name, frame)
+        key = cv.waitKey(1) & 0xFF
+        return key != ord("q")


### PR DESCRIPTION
## Summary
- introduce `PipelineManager` to decouple device handling
- use `VisualizationUtils` for common OpenCV displays
- update DepthAIPipeline to rely on `PipelineManager`
- add optional display flags for depthai scripts

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a541c6fc83309adf551021dc5e92