### PR TITLE
Add YAML config for script defaults

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,14 @@
+# Default configuration for blazepoze-detection scripts
+
+depthai:
+  classifier_blob: "models/deployed/pose_classifier_oak_openvino_2022.1_6shave.blob"
+  pose_blob: "depthai_blazepose/models/pose_landmark_full_sh4.blob"
+  camera_resolution: "1080p"
+  fps: 30
+  confidence_threshold: 0.5
+
+training:
+  data_dir: "data"
+  output_dir: "models/pretrained"
+  epochs: 30
+  batch_size: 32

--- a/scripts/run_depthai.py
+++ b/scripts/run_depthai.py
@@ -1,12 +1,17 @@
 import argparse
 import os
+import yaml
 from src.blazepoze.pipeline.depthai import DepthAIPipeline
 
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG_PATH = os.path.join(PROJECT_ROOT, "config.yaml")
+
+with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+    CONFIG = yaml.safe_load(f)
 
 
-def main(classifier_blob=None, pose_blob=None):
+def main(classifier_blob=None, pose_blob=None, resolution="1080p", fps=30, confidence_threshold=0.5):
     try:
         # Resolve to full paths relative to project root
         classifier_blob = os.path.join(PROJECT_ROOT, classifier_blob)
@@ -19,8 +24,11 @@ def main(classifier_blob=None, pose_blob=None):
             raise FileNotFoundError(f"BlazePose blob not found at: {pose_blob}")
 
         pipeline = DepthAIPipeline(
-            blob_file_path=classifier_blob,  # stage-2
-            blazepose_blob_path=pose_blob,   # stage-1
+            blob_file_path=classifier_blob,
+            blazepose_blob_path=pose_blob,
+            resolution=resolution,
+            fps=fps,
+            confidence_threshold=confidence_threshold,
         )
         print("Before connecting the device: ", pipeline)
         pipeline.connectDevice()
@@ -33,13 +41,30 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run DepthAI gesture pipeline")
     parser.add_argument(
         "--classifier-blob",
-        default="models/deployed/pose_classifier_oak_openvino_2022.1_6shave.blob",
+        default=CONFIG.get("depthai", {}).get("classifier_blob", "models/deployed/pose_classifier_oak_openvino_2022.1_6shave.blob"),
         help="Path to the gesture classifier blob",
     )
     parser.add_argument(
         "--pose-blob",
-        default="/Users/pedrootavionascimentocamposdeoliveira/PycharmProjects/hiveLabResearch/depthai_blazepose/models/pose_landmark_full_sh4.blob",
+        default=CONFIG.get("depthai", {}).get("pose_blob", "depthai_blazepose/models/pose_landmark_full_sh4.blob"),
         help="Path to the BlazePose blob",
     )
+    parser.add_argument(
+        "--resolution",
+        default=CONFIG.get("depthai", {}).get("camera_resolution", "1080p"),
+        help="Camera resolution (1080p, 720p, 4k)",
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=CONFIG.get("depthai", {}).get("fps", 30),
+        help="Camera frame rate",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=CONFIG.get("depthai", {}).get("confidence_threshold", 0.5),
+        help="Minimum confidence to display prediction",
+    )
     args = parser.parse_args()
-    main(args.classifier_blob, args.pose_blob)
+    main(args.classifier_blob, args.pose_blob, args.resolution, args.fps, args.threshold)

--- a/scripts/train_pipeline.py
+++ b/scripts/train_pipeline.py
@@ -1,6 +1,7 @@
 # Third-party libraries
 import argparse
 import os
+import yaml
 
 import numpy as np
 import pandas as pd
@@ -12,13 +13,35 @@ from tensorflow.keras.callbacks import EarlyStopping
 from src.blazepoze.pipeline.tnc_model_strong import build_tcn as tcn
 from src.blazepoze.pipeline.pose_dataset import PoseDatasetPipeline
 
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG_PATH = os.path.join(PROJECT_ROOT, "config.yaml")
+
+with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+    CONFIG = yaml.safe_load(f)
+
 
 def main():
     parser = argparse.ArgumentParser(description="Train pose classification model")
-    parser.add_argument("--data-dir", default="/Users/pedrootavionascimentocamposdeoliveira/PycharmProjects/hiveLabResearch/data", help="Directory with training data")
-    parser.add_argument("--output-dir", default="/Users/pedrootavionascimentocamposdeoliveira/PycharmProjects/hiveLabResearch/models/pretrained", help="Directory to save outputs")
-    parser.add_argument("--epochs", type=int, default=30)
-    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument(
+        "--data-dir",
+        default=CONFIG.get("training", {}).get("data_dir", "data"),
+        help="Directory with training data",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=CONFIG.get("training", {}).get("output_dir", "models/pretrained"),
+        help="Directory to save outputs",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=CONFIG.get("training", {}).get("epochs", 30),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=CONFIG.get("training", {}).get("batch_size", 32),
+    )
     args = parser.parse_args()
 
     SEQUENCE_LENGTH = 50


### PR DESCRIPTION
## Summary
- centralize common parameters in new `config.yaml`
- load configuration in `run_depthai.py` and expose as CLI options
- read training defaults from config in `train_pipeline.py`
- parameterize camera settings and confidence threshold in `DepthAIPipeline`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a77bfaf88330abbbe7d866c00d42